### PR TITLE
help: Make example config match the code

### DIFF
--- a/conf/gerrymander.conf-example
+++ b/conf/gerrymander.conf-example
@@ -70,8 +70,8 @@
 #[alias-nova-changes]
 # The name of the original command
 #basecmd=changes
-# A description for the new command
-#description=Nova open changes
+# A help text for the new command
+#help=Nova open changes
 
 
 # Each command line tool can have the default values for


### PR DESCRIPTION
get_command_alias_help looks for help not description. Otherwise you
see:

Traceback (most recent call last):
  File "scripts/gerrymander", line 22, in <module>
    sys.exit(CommandTool().execute(sys.argv[1:]))
  File "/var/scratch/src/gerrymander/gerrymander/gerrymander/commands.py", line 871, in execute
    self.add_config_commands(subparser, config)
  File "/var/scratch/src/gerrymander/gerrymander/gerrymander/commands.py", line 844, in add_config_commands
    help = config.get_command_alias_help(alias)
  File "/var/scratch/src/gerrymander/gerrymander/gerrymander/commands.py", line 162, in get_command_alias_help
    return self.config.get(section, "help")
  File "/usr/lib/python3.3/configparser.py", line 765, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'help' in section: 'alias-foo-changes'
