### PR TITLE
Use a preexec function to stop signals in subprocess

### DIFF
--- a/gerrymander/client.py
+++ b/gerrymander/client.py
@@ -34,13 +34,18 @@ class ClientLive(object):
         self.keyfile = keyfile
 
     def _run_async(self, argv):
+
+        def _preexec_fn():
+            os.setpgrp()
+
         stdout = subprocess.PIPE
         stderr = subprocess.PIPE
         LOG.debug("Running cmd %s" % " ".join(argv))
         sp = subprocess.Popen(argv,
                               stdout=stdout,
                               stderr=stderr,
-                              stdin=None)
+                              stdin=None,
+                              preexec_fn=_preexec_fn)
         return sp
 
     def _build_argv(self, cmdargv):


### PR DESCRIPTION
To avoid the subprocess from getting the signals that are
meant for the parent process by ensuring that the created
process is its own process group (which ensurse that it will
not get signals targeted for the calling process).

Fixes #16
