### PR TITLE
Add dependency output for changes and todo lists

### DIFF
--- a/gerrymander/commands.py
+++ b/gerrymander/commands.py
@@ -665,13 +665,13 @@ class CommandChanges(CommandProject, CommandCaching, CommandReportTable):
                              files=options.file,
                              usecolor=options.color)
 
-class CommandToDoMine(CommandProject, CommandCaching, CommandReportTable):
 
-    def __init__(self, name="todo-mine", help="List of changes I've looked at before"):
-        super(CommandToDoMine, self).__init__(name, help)
+class CommandToDo(CommandProject, CommandCaching, CommandReportTable):
+    def __init__(self, name, help):
+        super(CommandToDo, self).__init__(name, help)
 
     def add_options(self, parser, config):
-        super(CommandToDoMine, self).add_options(parser, config)
+        super(CommandToDo, self).add_options(parser, config)
 
         self.add_option(parser, config,
                         "--branch", action="append", default=[],
@@ -682,6 +682,11 @@ class CommandToDoMine(CommandProject, CommandCaching, CommandReportTable):
         self.add_option(parser, config,
                         "file", default=[], nargs="*",
                         help="File name matches")
+
+class CommandToDoMine(CommandToDo):
+
+    def __init__(self, name="todo-mine", help="List of changes I've looked at before"):
+        super(CommandToDoMine, self).__init__(name, help)
 
     def get_report(self, config, client, options):
         username = config.get_server_username()
@@ -697,23 +702,10 @@ class CommandToDoMine(CommandProject, CommandCaching, CommandReportTable):
                                   usecolor=options.color)
 
 
-class CommandToDoOthers(CommandProject, CommandCaching, CommandReportTable):
+class CommandToDoOthers(CommandToDo):
 
     def __init__(self, name="todo-others", help="List of changes I've not looked at before"):
         super(CommandToDoOthers, self).__init__(name, help)
-
-    def add_options(self, parser, config):
-        super(CommandToDoOthers, self).add_options(parser, config)
-
-        self.add_option(parser, config,
-                        "--branch", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "--topic", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "file", default=[], nargs="*",
-                        help="File name matches")
 
     def get_report(self, config, client, options):
         username = config.get_server_username()
@@ -729,23 +721,10 @@ class CommandToDoOthers(CommandProject, CommandCaching, CommandReportTable):
                                     usecolor=options.color)
 
 
-class CommandToDoAnyones(CommandProject, CommandCaching, CommandReportTable):
+class CommandToDoAnyones(CommandToDo):
 
     def __init__(self, name="todo-anyones", help="List of changes anyone has looked at"):
         super(CommandToDoAnyones, self).__init__(name, help)
-
-    def add_options(self, parser, config):
-        super(CommandToDoAnyones, self).add_options(parser, config)
-
-        self.add_option(parser, config,
-                        "--branch", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "--topic", action="append", default=[],
-                        help="Filter based on topic")
-        self.add_option(parser, config,
-                        "file", default=[], nargs="*",
-                        help="File name matches")
 
     def get_report(self, config, client, options):
         username = config.get_server_username()
@@ -762,23 +741,10 @@ class CommandToDoAnyones(CommandProject, CommandCaching, CommandReportTable):
                                      usecolor=options.color)
 
 
-class CommandToDoNoones(CommandProject, CommandCaching, CommandReportTable):
+class CommandToDoNoones(CommandToDo):
 
     def __init__(self, name="todo-noones", help="List of changes no one has looked at yet"):
         super(CommandToDoNoones, self).__init__(name, help)
-
-    def add_options(self, parser, config):
-        super(CommandToDoNoones, self).add_options(parser, config)
-
-        self.add_option(parser, config,
-                        "--branch", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "--topic", action="append", default=[],
-                        help="Filter based on topic")
-        self.add_option(parser, config,
-                        "file", default=[], nargs="*",
-                        help="File name matches")
 
     def get_report(self, config, client, options):
         return ReportToDoListNoones(client,
@@ -790,7 +756,7 @@ class CommandToDoNoones(CommandProject, CommandCaching, CommandReportTable):
                                     usecolor=options.color)
 
 
-class CommandToDoApprovable(CommandProject, CommandCaching, CommandReportTable):
+class CommandToDoApprovable(CommandToDo):
 
     def __init__(self, name="todo-approvable", help="List of changes that I can approve"):
         super(CommandToDoApprovable, self).__init__(name, help)
@@ -799,17 +765,8 @@ class CommandToDoApprovable(CommandProject, CommandCaching, CommandReportTable):
         super(CommandToDoApprovable, self).add_options(parser, config)
 
         self.add_option(parser, config,
-                        "--branch", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "--topic", action="append", default=[],
-                        help="Filter based on topic")
-        self.add_option(parser, config,
                         "--strict", action="store_true", default=False,
                         help="Exclude changes with any negative code reviews")
-        self.add_option(parser, config,
-                        "file", default=[], nargs="*",
-                        help="File name matches")
 
     def get_report(self, config, client, options):
         username = config.get_server_username()
@@ -826,7 +783,7 @@ class CommandToDoApprovable(CommandProject, CommandCaching, CommandReportTable):
                                         usecolor=options.color)
 
 
-class CommandToDoExpirable(CommandProject, CommandCaching, CommandReportTable):
+class CommandToDoExpirable(CommandToDo):
 
     def __init__(self, name="todo-expirable", help="List of stale changes that can be expired"):
         super(CommandToDoExpirable, self).__init__(name, help)
@@ -835,17 +792,8 @@ class CommandToDoExpirable(CommandProject, CommandCaching, CommandReportTable):
         super(CommandToDoExpirable, self).add_options(parser, config)
 
         self.add_option(parser, config,
-                        "--branch", action="append", default=[],
-                        help="Filter based on branch")
-        self.add_option(parser, config,
-                        "--topic", action="append", default=[],
-                        help="Filter based on topic")
-        self.add_option(parser, config,
                         "--age", default="28",
                         help="Set age cutoff in days")
-        self.add_option(parser, config,
-                        "file", default=[], nargs="*",
-                        help="File name matches")
 
     def get_report(self, config, client, options):
         return ReportToDoListExpirable(client,

--- a/gerrymander/commands.py
+++ b/gerrymander/commands.py
@@ -647,6 +647,9 @@ class CommandChanges(CommandProject, CommandCaching, CommandReportTable):
                         "--rawquery", default=None,
                         help="Raw query string to pass through to gerrit")
         self.add_option(parser, config,
+                        "--deps", action="store_true", default=False,
+                        help="Sort output by change dependencies")
+        self.add_option(parser, config,
                         "file", default=[], nargs="*",
                         help="File name matches")
         self.sort_option.choices = [c.key for c in ReportChanges.COLUMNS]
@@ -663,7 +666,8 @@ class CommandChanges(CommandProject, CommandCaching, CommandReportTable):
                              approvals=options.approval,
                              rawquery=options.rawquery,
                              files=options.file,
-                             usecolor=options.color)
+                             usecolor=options.color,
+                             deps=options.deps)
 
 
 class CommandToDo(CommandProject, CommandCaching, CommandReportTable):
@@ -679,6 +683,9 @@ class CommandToDo(CommandProject, CommandCaching, CommandReportTable):
         self.add_option(parser, config,
                         "--topic", action="append", default=[],
                         help="Filter based on topic")
+        self.add_option(parser, config,
+                        "--deps", action="store_true", default=False,
+                        help="Sort output by change dependencies")
         self.add_option(parser, config,
                         "file", default=[], nargs="*",
                         help="File name matches")
@@ -699,7 +706,8 @@ class CommandToDoMine(CommandToDo):
                                   branches=options.branch,
                                   files=options.file,
                                   topics=options.topic,
-                                  usecolor=options.color)
+                                  usecolor=options.color,
+                                  deps=options.deps)
 
 
 class CommandToDoOthers(CommandToDo):
@@ -718,7 +726,8 @@ class CommandToDoOthers(CommandToDo):
                                     branches=options.branch,
                                     files=options.file,
                                     topics=options.topic,
-                                    usecolor=options.color)
+                                    usecolor=options.color,
+                                    deps=options.deps)
 
 
 class CommandToDoAnyones(CommandToDo):
@@ -738,7 +747,8 @@ class CommandToDoAnyones(CommandToDo):
                                      branches=options.branch,
                                      files=options.file,
                                      topics=options.topic,
-                                     usecolor=options.color)
+                                     usecolor=options.color,
+                                     deps=options.deps)
 
 
 class CommandToDoNoones(CommandToDo):
@@ -753,7 +763,8 @@ class CommandToDoNoones(CommandToDo):
                                     branches=options.branch,
                                     files=options.file,
                                     topics=options.topic,
-                                    usecolor=options.color)
+                                    usecolor=options.color,
+                                    deps=options.deps)
 
 
 class CommandToDoApprovable(CommandToDo):
@@ -780,7 +791,8 @@ class CommandToDoApprovable(CommandToDo):
                                         branches=options.branch,
                                         files=options.file,
                                         topics=options.topic,
-                                        usecolor=options.color)
+                                        usecolor=options.color,
+                                        deps=options.deps)
 
 
 class CommandToDoExpirable(CommandToDo):
@@ -802,7 +814,8 @@ class CommandToDoExpirable(CommandToDo):
                                        branches=options.branch,
                                        files=options.file,
                                        topics=options.topic,
-                                       usecolor=options.color)
+                                       usecolor=options.color,
+                                       deps=options.deps)
 
 
 class CommandComments(CommandCaching):

--- a/gerrymander/model.py
+++ b/gerrymander/model.py
@@ -247,7 +247,9 @@ class ModelPatch(ModelBase):
 
 class ModelChange(ModelBase):
 
-    def __init__(self, project, branch, topic, id, number, subject, owner, url, createdOn, lastUpdated, status, patches = [], comments = []):
+    def __init__(self, project, branch, topic, id, number, subject, owner, url,
+                 createdOn, lastUpdated, status,
+                 patches = [], comments = [], depends = None):
         self.project = project
         self.branch = branch
         self.topic = topic
@@ -267,6 +269,7 @@ class ModelChange(ModelBase):
         self.status = status
         self.patches = patches
         self.comments = comments
+        self.depends = depends
 
     def get_current_patch(self):
         if len(self.patches) == 0:
@@ -383,6 +386,12 @@ class ModelChange(ModelBase):
         for c in data.get("comments", []):
             comments.append(ModelComment.from_json(c))
 
+        depends = None
+        dependsChange = data.get("dependsOn")
+        if dependsChange is not None and len(dependsChange) > 0:
+            # We only track a single dependency
+            depends = dependsChange[0].get("id")
+
         return ModelChange(data.get("project", None),
                            data.get("branch", None),
                            data.get("topic", None),
@@ -395,7 +404,8 @@ class ModelChange(ModelBase):
                            data.get("lastUpdated", None),
                            data.get("status", None),
                            patches,
-                           comments)
+                           comments,
+                           depends)
 
 
 class ModelEvent(ModelBase):

--- a/gerrymander/operations.py
+++ b/gerrymander/operations.py
@@ -36,7 +36,7 @@ class OperationQuery(OperationBase):
     STATUS_CLOSED = "closed"
 
     def __init__(self, client, terms={}, rawquery=None, patches=PATCHES_NONE,
-                 approvals=False, files=False, comments=False):
+                 approvals=False, files=False, comments=False, deps=False):
         OperationBase.__init__(self, client)
         self.terms = terms
         self.rawquery = rawquery
@@ -44,6 +44,7 @@ class OperationQuery(OperationBase):
         self.approvals = approvals
         self.files = files
         self.comments = comments
+        self.deps = deps
 
         if self.patches == OperationQuery.PATCHES_NONE:
             if self.approvals:
@@ -64,6 +65,8 @@ class OperationQuery(OperationBase):
             args.append("--files")
         if self.comments:
             args.append("--comments")
+        if self.deps:
+            args.append("--dependencies")
 
         clauses = []
         if limit is not None:

--- a/gerrymander/reports.py
+++ b/gerrymander/reports.py
@@ -858,13 +858,15 @@ class ReportBaseChange(ReportTable):
 class ReportChangeList(ReportBaseChange):
 
     def __init__(self, client, usecolor, title,
-                 query_terms, patches, files=None, rawquery=None):
+                 query_terms, patches, files=None, rawquery=None,
+                 deps=False):
         super(ReportChangeList, self).__init__(client, usecolor)
         self.title = title
         self.query_terms = query_terms
         self.patches = patches
         self.rawquery = rawquery
         self.files = files
+        self.deps = deps
 
     def filter(self, change):
         return True
@@ -931,7 +933,8 @@ class ReportChanges(ReportChangeList):
 
     def __init__(self, client, projects=[], owners=[],
                  status=[], messages=[], branches=[], topics=[], reviewers=[],
-                 approvals=[], files=[], rawquery=None, usecolor=False):
+                 approvals=[], files=[], rawquery=None, usecolor=False,
+                 deps=False):
         self.approvals = approvals
 
         query_terms = {
@@ -947,13 +950,13 @@ class ReportChanges(ReportChangeList):
                                             query_terms,
                                             OperationQuery.PATCHES_CURRENT,
                                             files=files,
-                                            rawquery=rawquery)
+                                            rawquery=rawquery, deps=deps)
 
 
 class ReportToDoList(ReportChangeList):
 
     def __init__(self, client, projects=[], branches=[],
-                 files=[], topics=[], reviewers=[], usecolor=False):
+                 files=[], topics=[], reviewers=[], usecolor=False, deps=False):
         query_terms = {
             "project": projects,
             "status": [ OperationQuery.STATUS_OPEN ],
@@ -965,13 +968,13 @@ class ReportToDoList(ReportChangeList):
                                              "Changes To Do List",
                                              query_terms,
                                              OperationQuery.PATCHES_ALL,
-                                             files)
+                                             files, deps=deps)
 
 
 class ReportToDoListMine(ReportToDoList):
 
     def __init__(self, client, username, projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes 'username' has
         reviewed an older version of the patch, and needs
@@ -983,7 +986,8 @@ class ReportToDoListMine(ReportToDoList):
                                                  branches=branches,
                                                  files=files,
                                                  topics=topics,
-                                                 usecolor=usecolor)
+                                                 usecolor=usecolor,
+                                                 deps=deps)
         self.username = username
 
     def filter(self, change):
@@ -995,7 +999,7 @@ class ReportToDoListMine(ReportToDoList):
 
 class ReportToDoListOthers(ReportToDoList):
     def __init__(self, client, username, bots=[], projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes where 'username' has
         never reviewed, but at least one other non-bot user has
@@ -1007,7 +1011,8 @@ class ReportToDoListOthers(ReportToDoList):
                                                    branches=branches,
                                                    files=files,
                                                    topics=topics,
-                                                   usecolor=usecolor)
+                                                   usecolor=usecolor,
+                                                   deps=deps)
         self.bots = bots
 
     def filter(self, change):
@@ -1023,7 +1028,7 @@ class ReportToDoListOthers(ReportToDoList):
 class ReportToDoListAnyones(ReportToDoList):
 
     def __init__(self, client, username, bots=[], projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes where at least
         one other non-bot user has provided review
@@ -1033,7 +1038,8 @@ class ReportToDoListAnyones(ReportToDoList):
                                                     branches=branches,
                                                     files=files,
                                                     topics=topics,
-                                                    usecolor=usecolor)
+                                                    usecolor=usecolor,
+                                                    deps=deps)
         self.bots = bots
         self.username = username
 
@@ -1048,7 +1054,7 @@ class ReportToDoListAnyones(ReportToDoList):
 class ReportToDoListNoones(ReportToDoList):
 
     def __init__(self, client, bots=[], projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes that no one
         has ever reviewed
@@ -1058,7 +1064,8 @@ class ReportToDoListNoones(ReportToDoList):
                                                    branches=branches,
                                                    files=files,
                                                    topics=topics,
-                                                   usecolor=usecolor)
+                                                   usecolor=usecolor,
+                                                   deps=deps)
         self.bots = bots
 
     def filter(self, change):
@@ -1070,7 +1077,7 @@ class ReportToDoListNoones(ReportToDoList):
 class ReportToDoListApprovable(ReportToDoList):
 
     def __init__(self, client, username, strict, projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes that no one
         has ever reviewed
@@ -1080,7 +1087,8 @@ class ReportToDoListApprovable(ReportToDoList):
                                                        branches=branches,
                                                        files=files,
                                                        topics=topics,
-                                                       usecolor=usecolor)
+                                                       usecolor=usecolor,
+                                                       deps=deps)
         self.username = username
         self.strict = strict
 
@@ -1103,7 +1111,7 @@ class ReportToDoListApprovable(ReportToDoList):
 class ReportToDoListExpirable(ReportToDoList):
 
     def __init__(self, client, age=28, projects=[],
-                 branches=[], files=[], topics=[], usecolor=False):
+                 branches=[], files=[], topics=[], usecolor=False, deps=False):
         '''
         Report to provide a list of changes that are
         stale and can potentially be expired
@@ -1113,7 +1121,8 @@ class ReportToDoListExpirable(ReportToDoList):
                                                       branches=branches,
                                                       files=files,
                                                       topics=topics,
-                                                      usecolor=usecolor)
+                                                      usecolor=usecolor,
+                                                      deps=deps)
         self.age = age
 
     def filter(self, change):

--- a/gerrymander/reports.py
+++ b/gerrymander/reports.py
@@ -32,6 +32,10 @@ from gerrymander.format import format_color
 
 LOG = logging.getLogger(__name__)
 
+
+TreeNode = collections.namedtuple('TreeNode', ['data', 'children'])
+
+
 class ReportOutputColumn(object):
 
     ALIGN_LEFT = "l"
@@ -224,22 +228,40 @@ class ReportOutputTable(ReportOutput):
     def add_column(self, col):
         self.columns.append(col)
 
-    def add_row(self, row):
-        self.rows.append(row)
+    def add_row(self, data, parent=None):
+        node = TreeNode(data, [])
 
-    def sort_rows(self):
+        if parent is None:
+            self.rows.append(node)
+        else:
+            parent.children.append(node)
+        return node
+
+    def iter_rowlist(self, init_rowlist, output_row, init_data, gen_child_data):
         sortcol = None
         for col in self.columns:
             if col.key == self.sortcol:
                 sortcol = col
 
-        if sortcol is not None:
-            self.rows.sort(key = lambda item: sortcol.get_sort_value(self, item),
-                           reverse=self.reverse)
+        total_written = [0]
+        def _iter_rowlist(rowlist, data):
+            if sortcol is not None:
+                rowlist.sort(key = lambda item: sortcol.get_sort_value(
+                                 self, item.data),
+                             reverse=self.reverse)
+
+            for row in rowlist:
+                if self.limit is not None and total_written[0] == self.limit:
+                    return
+                total_written[0] += 1
+
+                rowdata = output_row(row.data, data)
+
+                if len(row.children) > 0:
+                    _iter_rowlist(row.children, gen_child_data(rowdata))
+        _iter_rowlist(init_rowlist, init_data)
 
     def to_xml(self, doc, root):
-        self.sort_rows()
-
         table = doc.createElement("table")
         root.appendChild(table)
         if self.title is not None:
@@ -251,44 +273,53 @@ class ReportOutputTable(ReportOutput):
         table.appendChild(headers)
         table.appendChild(content)
 
-        for col in self.columns:
-            if col.visible:
-                xmlcol = doc.createElement(col.key)
-                xmlcol.appendChild(doc.createTextNode(col.label))
-                headers.appendChild(xmlcol)
+        visible_cols = filter(lambda col: col.visible, self.columns)
+        for col in visible_cols:
+            xmlcol = doc.createElement(col.key)
+            xmlcol.appendChild(doc.createTextNode(col.label))
+            headers.appendChild(xmlcol)
 
-        rows = self.rows
-        if self.limit is not None:
-            rows = rows[0:self.limit]
-        for row in rows:
+        def output_xml(row_data, parent):
             xmlrow = doc.createElement("row")
-            for col in self.columns:
-                if col.visible:
-                    xmlfield = doc.createElement(col.key)
-                    xmlfield.appendChild(doc.createTextNode(col.get_value(self, row)))
-                    xmlrow.appendChild(xmlfield)
-            content.appendChild(xmlrow)
+            for col in visible_cols:
+                xmlfield = doc.createElement(col.key)
+                xmlfield.appendChild(
+                    doc.createTextNode(col.get_value(self, row_data)))
+                xmlrow.appendChild(xmlfield)
+            parent.appendChild(xmlrow)
+            return xmlrow
+
+        def gen_children(parent):
+            children = doc.createElement("children")
+            parent.appendChild(children)
+            return children
+
+        self.iter_rowlist(self.rows, output_xml, content, gen_children)
 
         return doc
 
     def to_json(self, root):
-        self.sort_rows()
+        visible_cols = filter(lambda col: col.visible, self.columns)
 
         headers = {}
-        for col in self.columns:
-            if col.visible:
-                headers[col.key] = col.label
+        for col in visible_cols:
+            headers[col.key] = col.label
 
         content = []
-        rows = self.rows
-        if self.limit is not None:
-            rows = rows[0:self.limit]
-        for row in rows:
+
+        def output_json(row_data, parent):
             data = {}
-            for col in self.columns:
-                if col.visible:
-                    data[col.key] = col.get_value(self, row)
-            content.append(data)
+            for col in visible_cols:
+                data[col.key] = col.get_value(self, row_data)
+            parent.append(data)
+            return data
+
+        def gen_children(parent):
+            children = []
+            parent['children'] = children
+            return children
+
+        self.iter_rowlist(self.rows, output_json, content, gen_children)
 
         node = {
             "table": {
@@ -301,27 +332,28 @@ class ReportOutputTable(ReportOutput):
         root.append(node)
 
     def to_text(self):
-        self.sort_rows()
-
         labels = []
-        for col in self.columns:
-            if col.visible:
-                labels.append(col.label)
+        visible_cols = filter(lambda col: col.visible, self.columns)
+        for col in visible_cols:
+            labels.append(col.label)
         table = prettytable.PrettyTable(labels)
-        for col in self.columns:
+        for col in visible_cols:
             table.align[col.label] = col.align
 
         table.padding_width = 1
+        indent = 2
 
-        rows = self.rows
-        if self.limit is not None:
-            rows = rows[0:self.limit]
-        for row in rows:
-            data = []
-            for col in self.columns:
-                if col.visible:
-                    data.append(col.get_value(self, row))
-            table.add_row(data)
+        def output_text(row_data, depth):
+            fields = map(lambda col: col.get_value(self, row_data),
+                         visible_cols)
+            fields[0] = ' ' * indent * depth + fields[0]
+            table.add_row(fields)
+            return depth
+
+        def inc_depth(depth):
+            return depth + 1
+
+        self.iter_rowlist(self.rows, output_text, 0, inc_depth)
 
         prolog = ""
         if self.title is not None:
@@ -329,29 +361,25 @@ class ReportOutputTable(ReportOutput):
         return prolog + str(table) + "\n"
 
     def to_csv(self):
-        self.sort_rows()
-
-        labels = []
-        for col in self.columns:
-            if col.visible:
-                labels.append(col.label)
+        visible_cols = filter(lambda col: col.visible, self.columns)
 
         lines = []
 
         if self.title is not None:
             lines.append(self.title)
 
+        labels = []
+        for col in visible_cols:
+            labels.append(col.label)
         lines.append(",".join(labels))
 
-        rows = self.rows
-        if self.limit is not None:
-            rows = rows[0:self.limit]
-        for row in rows:
-            data = []
-            for col in self.columns:
-                if col.visible:
-                    data.append(col.get_value(self, row))
+        # CSV data is flat
+        def output_csv(row_data, dummy):
+            data = map(lambda col: col.get_value(self, row_data), visible_cols)
             lines.append(",".join(data))
+            return dummy
+
+        self.iter_rowlist(self.rows, output_csv, None, lambda x: None)
 
         return "\n".join(lines)
 


### PR DESCRIPTION
Add a --deps option which causes report output to represent a single-parented dependency hierarchy between changes.

e.g.:
| NEW       | https://review.openstack.org/127991 | garyk         | VMware: add tests for spawn wi... 
| NEW       | https://review.openstack.org/128931 | garyk         | VMware: refactor cpu allocatio... 
|   NEW     | https://review.openstack.org/68421  | garyk         | VMWare: get storage policy fro...
|     NEW   | https://review.openstack.org/68539  | sabari        | VMware: use storage policy in ... 

Warning: I haven't tested this on all commands! However, as I've included some consolidation, hopefully the coverage is ok. I expect it to work :)