### PR TITLE
reports: Don't fail on int types

### DIFF
--- a/gerrymander/reports.py
+++ b/gerrymander/reports.py
@@ -56,7 +56,10 @@ class ReportOutputColumn(object):
             val = ""
 
         if type(val) != str:
-            val = val.encode('utf-8')
+            try:
+                val = val.encode('utf-8')
+            except AttributeError:
+                val = str(val)
 
         if self.truncate and len(val) > self.truncate:
             val = val[0:self.truncate] + "..."


### PR DESCRIPTION
The reports can contain integers so don't try to use encode on them:

    $ gerrymander patchreviewstats --project puppet
    Traceback (most recent call last):
      File "/usr/bin/gerrymander", line 22, in <module>
        sys.exit(CommandTool().execute(sys.argv[1:]))
      File "/usr/lib/python2.7/dist-packages/gerrymander/commands.py", line 1078, in execute
        options.func(config, options)
      File "/usr/lib/python2.7/dist-packages/gerrymander/commands.py", line 219, in execute
        self.run(config, client, options)
      File "/usr/lib/python2.7/dist-packages/gerrymander/commands.py", line 550, in run
        return super(CommandPatchReviewStats, self).run(config, client, options)
      File "/usr/lib/python2.7/dist-packages/gerrymander/commands.py", line 513, in run
        report.display(options.mode)
      File "/usr/lib/python2.7/dist-packages/gerrymander/reports.py", line 370, in display
        output.display(mode)
      File "/usr/lib/python2.7/dist-packages/gerrymander/reports.py", line 86, in display
        stream.write(self.to_text())
      File "/usr/lib/python2.7/dist-packages/gerrymander/reports.py", line 125, in to_text
        blocks.append(report.to_text())
      File "/usr/lib/python2.7/dist-packages/gerrymander/reports.py", line 324, in to_text
        data.append(col.get_value(self, row))
      File "/usr/lib/python2.7/dist-packages/gerrymander/reports.py", line 60, in get_value
        val = val.encode('utf-8')
    AttributeError: 'int' object has no attribute 'encode'