### PR TITLE
add support for getting gerrit server from git remote

### DIFF
--- a/gerrymander/commands.py
+++ b/gerrymander/commands.py
@@ -36,6 +36,7 @@ from gerrymander.model import ModelEventChangeAbandon
 from gerrymander.model import ModelEventChangeRestore
 from gerrymander.model import ModelApproval
 from gerrymander.pager import start_pager, stop_pager
+from gerrymander.git import get_remote_info
 
 import getpass
 import os
@@ -55,6 +56,25 @@ class CommandConfig(object):
         self.filename = os.path.expanduser(filename)
         self.config = configparser.ConfigParser()
         self.config.read([self.filename])
+
+        if self.has_option('server', 'remote'):
+            self.set_gerrit_from_remote()
+
+    def set_gerrit_from_remote(self):
+        remote = self.get_option_string('server', 'remote')
+        if not remote:
+            return
+
+        user, host, port = get_remote_info(remote)
+
+        if host:
+            self.config.set('server', 'hostname', host)
+
+        if user:
+            self.config.set('server', 'username', user)
+
+        if port:
+            self.config.set('server', 'port', port)
 
     def has_option(self, section, name):
         return self.config.has_option(section, name)

--- a/gerrymander/git.py
+++ b/gerrymander/git.py
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2014 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+import urlparse
+
+def get_git_config(key):
+    '''Read a git configuration value use "git config --get ..."'''
+    val = subprocess.check_output([
+        'git', 'config', '--get', key])
+
+    return val
+
+def get_remote_info(remote):
+    '''Read information for the named remote from the git configuration
+    and return a (user, host, port) tuple.'''
+    url = get_git_config('remote.%s.url' % remote)
+    if not url:
+        return
+
+    # only ssh urls make sense.  arguably this should support the
+    # user@host:path syntax as well, but remotes configured using
+    # "git review -s" will never look like that.
+    if not url.startswith('ssh://'):
+        return
+
+    url = urlparse.urlparse(url)
+    
+    try:
+        userhost, port = url.netloc.split(':')
+    except ValueError:
+        port = None
+        userhost = url.netloc
+
+    try:
+        user, host = userhost.split('@')
+    except ValueError:
+        user = None
+        host = url.netloc
+
+    return (user, host, port)


### PR DESCRIPTION
With this change, you can configure your `.gerrymander` file like
this:

    [server]
    remote = gerrit

And gerrymander will read the user, host, and port from the named
remote in whatever git repository you happen to be using at the time.
This is especially convenient when your work environment includes
projects hosted at multiple gerrit sites.